### PR TITLE
Fix crash when location API returns non-string zone

### DIFF
--- a/server/routes/location.js
+++ b/server/routes/location.js
@@ -29,8 +29,8 @@ router.post('/', (req, res) => {
 
   const { zone, timestamp } = req.body;
 
-  if (!zone) {
-    return res.status(400).json({ error: 'Missing zone field' });
+  if (!zone || typeof zone !== 'string') {
+    return res.status(400).json({ error: 'Missing or invalid zone field (must be a string)' });
   }
 
   const location = {

--- a/src/contexts/CartLocationContext.jsx
+++ b/src/contexts/CartLocationContext.jsx
@@ -18,6 +18,7 @@ export function CartLocationProvider({ children }) {
         const response = await fetch('/api/location');
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data = await response.json();
+        if (typeof data.zone !== 'string') data.zone = 'unknown';
         setLocation(data);
         setError(null);
       } catch (err) {


### PR DESCRIPTION
Server: validate zone is a string before saving, reject with 400. Frontend: normalize non-string zone to 'unknown' so CartMap shows 'Locatie onbekend' instead of crashing with React error #31.

Root cause: something POSTed {"zone": {"anus":1}} which bypassed the missing-field check and got stored in location.json.